### PR TITLE
Alert logic workaround

### DIFF
--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -35,10 +35,14 @@
           - cidr: 172.24.128.0/18
             az:  "{{ region }}c"
             resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet C", "teamDL": "universal.publishing.platform@ft.com}"}
-
+            
+          # AlertLogic/CloudInsight subnets. Not used by Coco cluster.
           - cidr: 172.24.192.0/28
             az:  "{{ region }}c"
-            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet C", "teamDL": "universal.publishing.platform@ft.com}"}
+            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
+          - cidr: 172.24.192.16/28
+            az:  "{{ region }}a"
+            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
 
         internet_gateway: True
         route_tables:
@@ -46,7 +50,9 @@
               - 172.24.0.0/18
               - 172.24.64.0/18
               - 172.24.128.0/18
+              # AlertLogic/CloudInsight routing tables. Not used by Coco cluster. 
               - 172.24.192.0/28
+              - 172.24.192.16/28
             routes:
               - dest: 0.0.0.0/0
                 gw: igw

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -35,12 +35,18 @@
           - cidr: 172.24.128.0/18
             az:  "{{ region }}c"
             resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet C", "teamDL": "universal.publishing.platform@ft.com}"}
+
+          - cidr: 172.24.192.0/28
+            az:  "{{ region }}c"
+            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet C", "teamDL": "universal.publishing.platform@ft.com}"}
+
         internet_gateway: True
         route_tables:
           - subnets:
               - 172.24.0.0/18
               - 172.24.64.0/18
               - 172.24.128.0/18
+              - 172.24.192.0/28
             routes:
               - dest: 0.0.0.0/0
                 gw: igw

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -43,6 +43,9 @@
           - cidr: 172.24.192.16/28
             az:  "{{ region }}a"
             resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
+          - cidr: 172.24.192.32/28
+            az:  "{{ region }}a"
+            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
 
         internet_gateway: True
         route_tables:
@@ -53,6 +56,7 @@
               # AlertLogic/CloudInsight routing tables. Not used by Coco cluster. 
               - 172.24.192.0/28
               - 172.24.192.16/28
+              - 172.24.192.32/28
             routes:
               - dest: 0.0.0.0/0
                 gw: igw


### PR DESCRIPTION
Hi @tamas-molnar and @BerniVarga ,
Here is the pull request that works around the issue with provisioning.
I'm expecting 3rd AlertLogic subnet to appear at some point which will break the deployment again.
We need to add this new subnet to aws_coreos_site.yml file once we have details for it.
After that I'm hoping that there won't be any new subnets created by AlertLogic. 
Could you give this a try and let me know if it works for you. 
I can then port same workaround to main coco-provisioner project. 
Thanks,
jussi
