### PR TITLE
Fix ansible_python_interpreter in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN echo "[localhost]" > ~/.ansible_hosts \
- && echo '127.0.0.1 ansible_python_interpreter=$VIRTUAL_ENV/bin/python' >> ~/.ansible_hosts \
+ && echo '127.0.0.1 ansible_python_interpreter=/.venv/bin/python' >> ~/.ansible_hosts \
  && apk --update add py-pip py-virtualenv gcc python-dev libffi-dev openssl-dev build-base bash jq util-linux curl \
  && mkdir .venv \
  && virtualenv .venv \
@@ -14,4 +14,3 @@ RUN ln -s /cluster-id-extractor /usr/local/bin/cluster-id-extractor
 ADD ansible/ /ansible
 
 CMD /bin/bash provision.sh
-


### PR DESCRIPTION
Previosly Docker build injected shell variable $VIRTUAL_ENV into .ansible_hosts file.
Ansible does not understand shell variables. Therefore variable must be replaced with absolute path.

Error thrown by Ansible 2.1.0.0 before the change.
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948 `" && echo ansible-tmp-1469614187.86-96561901694948="` echo $HOME/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmpve0Ugw TO /root/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948/setup
<127.0.0.1> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 $VIRTUAL_ENV/bin/python /root/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948/setup; rm -rf "/root/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948/" > /dev/null 2>&1 && sleep 0'
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948/setup", line 114, in <module>
    exitcode = invoke_module(module, zipped_mod, ZIPLOADER_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948/setup", line 28, in invoke_module
    p = subprocess.Popen(['$VIRTUAL_ENV/bin/python', module], env=os.environ, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "setup"}, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948/setup\", line 114, in <module>\n    exitcode = invoke_module(module, zipped_mod, ZIPLOADER_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1469614187.86-96561901694948/setup\", line 28, in invoke_module\n    p = subprocess.Popen(['$VIRTUAL_ENV/bin/python', module], env=os.environ, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)\n  File \"/usr/lib/python2.7/subprocess.py\", line 711, in __init__\n    errread, errwrite)\n  File \"/usr/lib/python2.7/subprocess.py\", line 1343, in _execute_child\n    raise child_exception\nOSError: [Errno 2] No such file or directory\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
