### PR TITLE
Add docker host config with higher drop-in number to override old one

### DIFF
--- a/ansible/userdata/persistent_instance_user_data.yaml
+++ b/ansible/userdata/persistent_instance_user_data.yaml
@@ -50,10 +50,10 @@ coreos:
           WantedBy=timers.target
     - name: docker.service
       drop-ins:
-        - name: 10-turn-off-logging.conf
+        - name: 11-docker-opts.conf
           content: |
             [Service]
-            Environment="DOCKER_OPTS=--log-driver=none"
+            Environment="DOCKER_OPTS=--log-driver=none --host 0.0.0.0:2375"
       command: start
     - name: swapon.service
       command: start


### PR DESCRIPTION
* see https://docs.google.com/document/d/1d21pm21vOCxNqrglCLzNj-Mr0xrnMc6gqZS0V-zse90/edit#
* haven't provisioned a new cluster with this but I have used the userdata manually in xp and it works
