### PR TITLE
Fix clusterid typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-    coco/coco-pub-provisioner:v1.0.1
+    coco/coco-pub-provisioner:v1.0.2
 
 ## IMPORTANT NOTE: Due to some unknown reason setting BRIGHTCOVE_AUTH did not work as expected. Once the cluster is running
 ## please check the etcd value for /ft/_credentials/brightcove_auth and correct it if necessary.
@@ -61,28 +61,6 @@ docker run \
 ```
 
 If you need a Docker runtime environment to provision a cluster you can set up [Coco Management Server](https://github.com/Financial-Times/coco-pub-provisioner/blob/master/cloudformation/README.md) in AWS.
-
-Set up HTTPS support
---------------------
-
-To access URLs from the cluster through HTTPS, we need to add support for this in the load balancer of this cluster
-
-* log on to one of the machines in AWS
-* pick a HC url, like `foo-up.ft.com`, (where `foo` is the ENVIRONMENT_TAG you defined for this cluster) and execute `dig foo-up.ft.com`
-* the answer section will look something like this:
-
-```
-;; ANSWER SECTION:
-foo-up.ft.com.        600    IN    CNAME    bar1426.eu-west-1.elb.amazonaws.com.
-```
-
-* This is the ELB for the cluster on which the HC is running: `bar1426.eu-west-1.elb.amazonaws.com`
-
-* in the AWS console > EC2 > Load Balancers > search for the LB
-* click on it > Listeners > Edit > Add HTTPS on instance port `80`
-* to know which SSL certificate to choose, check what the LBs of other clusters (which have https enabled) are using
-* save and try if it works, ex. `https://foo-up.ft.com`
-* you can also remove HTTP support if needed
 
 Decommission an environment
 ---------------------------
@@ -113,7 +91,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.1 /bin/bash /decom.sh
+  coco/coco-pub-provisioner:v1.0.2 /bin/bash /decom.sh
 ```
 
 Sometimes cleanup takes a long time and ELBs/Security Groups still get left behind. Other ways to clean up:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ docker run \
 ## IMPORTANT NOTE: Due to some unknown reason setting BRIGHTCOVE_AUTH did not work as expected. Once the cluster is running
 ## please check the etcd value for /ft/_credentials/brightcove_auth and correct it if necessary.
 
-## If the cluster is running, set up HTTPS support (see below)
 ```
 
 If you need a Docker runtime environment to provision a cluster you can set up [Coco Management Server](https://github.com/Financial-Times/coco-pub-provisioner/blob/master/cloudformation/README.md) in AWS.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-    coco/coco-pub-provisioner:v1.0.2
+    coco/coco-pub-provisioner:v1.0.3
 
 ## IMPORTANT NOTE: Due to some unknown reason setting BRIGHTCOVE_AUTH did not work as expected. Once the cluster is running
 ## please check the etcd value for /ft/_credentials/brightcove_auth and correct it if necessary.
@@ -91,7 +91,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.2 /bin/bash /decom.sh
+  coco/coco-pub-provisioner:v1.0.3 /bin/bash /decom.sh
 ```
 
 Sometimes cleanup takes a long time and ELBs/Security Groups still get left behind. Other ways to clean up:

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -159,9 +159,11 @@
           - "{{ vpc.subnets[1].id }}"
           - "{{ vpc.subnets[2].id }}"
         listeners:
-          - protocol: http
-            load_balancer_port: 80
+          - protocol: https
+            load_balancer_port: 443
+            instance_protocol: http
             instance_port: 80
+            ssl_certificate_id: "arn:aws:iam::027104099916:server-certificate/wildcard.ft.com"
         purge_listeners: True
         health_check:
           ping_protocol: tcp # options are http, https, ssl, tcp

--- a/decom.sh
+++ b/decom.sh
@@ -7,8 +7,8 @@ echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY" >> /etc/boto.cfg
 ## activate virtual environment
 . .venv/bin/activate
 
-CLUSTER_ID=$(aws ec2 describe-instances --filter Name=tag:coco-environment-tag,Values=$ENVIRONMENT_TAG | jq '.Reservations[0].Instances[0].Tags[]' | cluster-id-extractor)
-echo "ClusterID: $CLUSTER_ID"
+CLUSTERID=$(aws ec2 describe-instances --filter Name=tag:coco-environment-tag,Values=$ENVIRONMENT_TAG | jq '.Reservations[0].Instances[0].Tags[]' | cluster-id-extractor)
+echo "ClusterID: $CLUSTERID"
 
 INSTANCE_IDS=$(aws ec2 describe-instances --filter Name=tag:coco-environment-tag,Values=$ENVIRONMENT_TAG | jq '{"instanceIds": [.Reservations[].Instances[].InstanceId]}')
 INSTANCE_IDS=`echo $INSTANCE_IDS`


### PR DESCRIPTION
This fixes the bug where ELBs and SGs aren't being removed properly when the decomission scripts are run.
Test cluster spun up and torn down successfully.