### PR TITLE
Add warning re: creating test clusters in US

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -54,7 +54,7 @@ export CLUSTER_BASIC_HTTP_CREDENTIALS=
 ## Pre-Prod: test.api.ft.com
 export API_HOST=
 
-# Unused here, but useful in decomissioning.
+# Region to create the cluster.
 export AWS_DEFAULT_REGION=eu-west-1
 
 # The following variable specifies URLs for read access to the delivery clusters, which are required by publishing monitoring services.
@@ -83,6 +83,9 @@ export MAPPINGS_BERTHA_URL=http://bertha.site.example/123456XYZ/Mapping
 
 Run the image
 -------------
+
+Currently, attempting to provision a cluster in `us-east-1` with an environment type of `t` causes the security group creation to fail.
+Everything else works fine - `t` or `p` clusters in `eu-west-1`, and `p` clusters in `us-east-1`.
 
 ```bash
 docker run \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ See [SSH_README.md](/SSH_README.md/)
 Provision a publishing cluster
 ------------------------------
 
+Currently, attempting to provision a cluster in `us-east-1` with an environment type of `t` causes the security group creation to fail.
+Everything else works fine - `t` or `p` clusters in `eu-west-1`, and `p` clusters in `us-east-1`.
+
 ```bash
 ## Set all the environment variables required to provision a cluster. These variables are stored in LastPass
 ## For PROD cluster

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -2,7 +2,6 @@
   connection: local
 
   vars:
-    region: eu-west-1
     ami: ami-c26bcab1 #eu-west-1 HMV 835.9.0 (stable)
     #ami: ami-c3cae3b4 #eu-west-1 HMV CoreOS 815.0.0 (alpha)
     env: "{{ environment_type }}"


### PR DESCRIPTION
There's a super weird interaction between the environment tag and availability zone variables.
The end result is that if you create a cluster with environment tag of `t` in `us-east-1`, it will fail to create the subnets correctly.
Everything else works fine - `t` or `p` clusters in `eu-west-1`, and `p` clusters in `us-east-1`.

Since we're unlikely to need to create many non-prod clusters in US, I'm adding a note to the documentation in the meantime while I investigate, and we can always retag the instances etc if required.