### PR TITLE
Increase SG deletion wait period

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-    coco/coco-pub-provisioner:v1.0.5
+    coco/coco-pub-provisioner:v1.0.6
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```
@@ -90,20 +90,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.5 /bin/bash /decom.sh
-```
-
-Sometimes cleanup takes a long time and ELBs/Security Groups still get left behind. Other ways to clean up:
-
-```sh
-# List all coreos security groups
-aws ec2 describe-security-groups | jq -r '.SecurityGroups[] | .GroupName + " " + .GroupId' | grep coreos
-
-# Delete coreos security groups not in use, does not filter - will fail on any group that is being used
-aws ec2 describe-security-groups | jq -r '.SecurityGroups[] | .GroupName + " " + .GroupId' | grep coreos | awk '{print $2}' | xargs -I {} -n1 sh -c 'aws ec2 delete-security-group --group-id {} || echo {} is active'
-
-# Delete ELBs that have no instances AND there are no instances with the same group name (stopped) as the ELB
-aws elb describe-load-balancers | jq -r '.LoadBalancerDescriptions[] | select(.Instances==[]) | .LoadBalancerName' | grep coreos | xargs -I {} sh -c "aws ec2 describe-instances --filters "Name=tag-key,Values=coco-environment-tag" | jq -e '.Reservations[].Instances[].SecurityGroups[] | select(.GroupName==\"{}\")' >/dev/null 2>&1 || echo {}" | xargs -n1 -I {} aws elb delete-load-balancer --load-balancer-name {}
+  coco/coco-pub-provisioner:v1.0.6 /bin/bash /decom.sh
 ```
 
 Coco Management Server

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -35,8 +35,8 @@
         name: "coreos-up-{{clusterid}}"
         state: absent
 
-    - name: Wait 60s for elb to be terminated and release enis
-      shell: "sleep 60"
+    - name: Wait 120s for elb to be terminated and release enis
+      shell: "sleep 120"
 
     - name: Delete fleet security group
       ec2_group:


### PR DESCRIPTION
Increase the wait period before we try to clean up the security group from 1 minute to 2 minutes.

This should prevent the SGs from failing to delete due to dependent objects - 2 mins should be plenty for the ENIs to be removed.