### PR TITLE
Print cluster tunnel address

### DIFF
--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -285,5 +285,5 @@
           coco-environment-tag: "{{environment_tag}}"
 
     - name: Cluster tunnel DNS address
-      debug: msg="Cluster tunnel DNS address: {{ environment_tag }}-tunnel-up.ft.com"
+      debug: msg="Cluster tunnel DNS address - {{ environment_tag }}-tunnel-up.ft.com"
 

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -283,3 +283,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+
+    - name: Cluster tunnel DNS address
+      debug: msg="Cluster tunnel DNS address: {{ environment_tag }}-tunnel-up.ft.com"
+


### PR DESCRIPTION
Prints the cluster tunnel address once provisioning is complete.

Requested by @jussi-ft .