### PR TITLE
Use gp2 disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-    coco/coco-pub-provisioner:v1.0.6
+    coco/coco-pub-provisioner:v1.0.7
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```
@@ -93,7 +93,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.6 /bin/bash /decom.sh
+  coco/coco-pub-provisioner:v1.0.7 /bin/bash /decom.sh
 ```
 
 Coco Management Server

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -197,9 +197,11 @@
         volumes:
           - device_name: /dev/xvda
             volume_size: 30
+            volume_type: gp2
             delete_on_termination: true
           - device_name: /dev/xvdf
             volume_size: 400
+            volume_type: gp2
             delete_on_termination: true
         count_tag:
           Name: "ftpr1{{clusterid}}-caw1a-eu-p"
@@ -232,9 +234,11 @@
         volumes:
           - device_name: /dev/xvda
             volume_size: 30
+            volume_type: gp2
             delete_on_termination: true
           - device_name: /dev/xvdf
             volume_size: 400
+            volume_type: gp2
             delete_on_termination: true
         count_tag:
           Name: "ftpr2{{clusterid}}-caw1b-eu-p"
@@ -267,9 +271,11 @@
         volumes:
           - device_name: /dev/xvda
             volume_size: 30
+            volume_type: gp2
             delete_on_termination: true
           - device_name: /dev/xvdf
             volume_size: 400
+            volume_type: gp2
             delete_on_termination: true
         count_tag:
           Name: "ftpr3{{clusterid}}-caw1c-eu-p"


### PR DESCRIPTION
Provision publishing clusters with GP2 storage instead of magnetic disks.