### PR TITLE
Bump version and try badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+ [![GitHub release](https://img.shields.io/badge/version-v1.0.9-green.svg?style=flat)](https://github.com/Financial-Times/coco-pub-provisioner/releases)
+
 Docker image to provision a cluster
 ===================================
 
@@ -60,7 +62,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-     coco/coco-pub-provisioner:v1.0.8
+     coco/coco-pub-provisioner:v1.0.9
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```


### PR DESCRIPTION
Upgrade to v.1.0.9

What do people think of the [badge](https://github.com/Financial-Times/coco-pub-provisioner/blob/v1.0.9/README.md)? 