### PR TITLE
Auto termination protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.8 /bin/bash /decom.sh
+  coco/coco-pub-provisioner:v1.0.11 /bin/bash /decom.sh
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- [![GitHub release](https://img.shields.io/badge/version-v1.0.10-green.svg?style=flat)](https://github.com/Financial-Times/coco-pub-provisioner/releases)
+ [![GitHub release](https://img.shields.io/badge/version-v1.0.11-green.svg?style=flat)](https://github.com/Financial-Times/coco-pub-provisioner/releases)
 
 Docker image to provision a cluster
 ===================================
@@ -64,7 +64,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-     coco/coco-pub-provisioner:v1.0.10
+     coco/coco-pub-provisioner:v1.0.11
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -178,6 +178,10 @@
 
     - debug: msg="cluster_elb dns {{ cluster_elb.elb.dns_name }}"
 
+    - name: Set termination protection for production clusters
+      set_fact:
+        termination_protection: "{% if env == 'p' %}yes{% else %}no{% endif %}"
+
     - set_fact:
         persistent_tag: 1
 
@@ -214,6 +218,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - set_fact:
         persistent_tag: 2
@@ -251,6 +256,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - set_fact:
         persistent_tag: 3
@@ -288,6 +294,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - name: Cluster tunnel DNS address
       debug: msg="Cluster tunnel DNS address - {{ environment_tag }}-tunnel-up.ft.com"


### PR DESCRIPTION
If environment_type is production, automagically enable termination protection.  

Otherwise, leave it turned off by default.
