### PR TITLE
Fix DNS decomissioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "[localhost]" > ~/.ansible_hosts \
  && mkdir .venv \
  && virtualenv .venv \
  && . .venv/bin/activate \
- && pip install ansible boto awscli
+ && pip install ansible==2.0.2.0 boto awscli
 
 ADD *.sh /
 ADD cluster-id-extractor /

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-     coco/coco-pub-provisioner:v1.0.11
+     coco/coco-pub-provisioner:v1.0.12
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```
@@ -100,7 +100,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.11 /bin/bash /decom.sh
+  coco/coco-pub-provisioner:v1.0.12 /bin/bash /decom.sh
 ```
 
 

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -16,13 +16,24 @@
         instance_ids: "{{instanceIds}}"
 
     - name: Delete DNS tunnel record
-      shell: "curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic {{konstructor_api_key}} \" \"https://konstructor.ft.com/v1/dns/delete?zone=ft.com&name={{environment_tag}}-tunnel-up\""
+      uri:
+        url: "https://dns-api.in.ft.com/v2/"
+        method: DELETE
+        HEADER_x-api-key: "{{konstructor_api_key}}"
+        body:
+          zone: "ft.com"
+          name: "{{environment_tag}}-tunnel-up"
+        body_format: json
 
-    - name: Delete DNS elb record
-      shell: "curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic {{konstructor_api_key}} \" \"https://konstructor.ft.com/v1/dns/delete?zone=ft.com&name={{environment_tag}}-up\""
-
-    - name: Delete DNS elb read record
-      shell: "curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic {{konstructor_api_key}} \" \"https://konstructor.ft.com/v1/dns/delete?zone=ft.com&name={{environment_tag}}-up-read\""
+    - name: Delete DNS ELB record
+      uri:
+        url: "https://dns-api.in.ft.com/v2/"
+        method: DELETE
+        HEADER_x-api-key: "{{konstructor_api_key}}"
+        body:
+          zone: "ft.com"
+          name: "{{environment_tag}}-up"
+        body_format: json
 
     - name: Wait 120s for instances to be terminated and release enis
       shell: "sleep 120"


### PR DESCRIPTION
The decomissioning playbook was still using Konstructor v1, which has been disabled, so none of our DNS records were getting removed when clusters were decomissioned.

Now updated to use Konstructor v2, and also uses Ansible's URI method instead of `curl`ing. Minor Ansible version bump to accomodate this.