### PR TITLE
Mask update engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-     coco/coco-pub-provisioner:v1.0.14
+     coco/coco-pub-provisioner:v1.0.15
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```
@@ -100,7 +100,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.14 /bin/bash /decom.sh
+  coco/coco-pub-provisioner:v1.0.15 /bin/bash /decom.sh
 ```
 
 

--- a/ansible/userdata/persistent_instance_user_data.yaml
+++ b/ansible/userdata/persistent_instance_user_data.yaml
@@ -22,6 +22,7 @@ coreos:
   units:
     - name: update-engine.service
       command: stop
+      mask: true
     - name: locksmithd.service
       command: stop
     - name: authorized_keys.service


### PR DESCRIPTION
* same change as in https://github.com/Financial-Times/coco-provisioner/pull/149
* provisioned a cluster, change worked:

```
$ sudo systemctl status update-engine
● update-engine.service
   Loaded: masked (/dev/null; bad)
   Active: failed (Result: exit-code) since Mon 2016-10-10 08:17:37 UTC; 55s ago

$ sudo systemctl unmask update-engine
Removed symlink /etc/systemd/system/update-engine.service.

$ sudo systemctl status update-engine
● update-engine.service - Update Engine
   Loaded: loaded (/usr/lib64/systemd/system/update-engine.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Mon 2016-10-10 08:17:37 UTC; 1min 3s ago

$ sudo systemctl start update-engine

$ journalctl -fu update-engine
systemd[1]: Starting Update Engine...
update_engine[2389]: [1010/081844:INFO:main.cc(155)] CoreOS Update Engine starting
systemd[1]: Started Update Engine.
update_engine[2389]: [1010/081844:INFO:update_check_scheduler.cc(82)] Next update check in 2m30s


```