### PR TITLE
Add Konstructor email for DNS changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker run \
     -e "AUTHORS_BERTHA_URL=$AUTHORS_BERTHA_URL" \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-     coco/coco-pub-provisioner:v1.0.17
+     coco/coco-pub-provisioner:v1.0.18
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```
@@ -103,7 +103,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-pub-provisioner:v1.0.17 /bin/bash /decom.sh
+  coco/coco-pub-provisioner:v1.0.18 /bin/bash /decom.sh
 ```
 
 

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -23,6 +23,7 @@
         body:
           zone: "ft.com"
           name: "{{environment_tag}}-tunnel-up"
+        emailAddress: "euan.finlay@ft.com"
         body_format: json
 
     - name: Delete DNS ELB record
@@ -33,6 +34,7 @@
         body:
           zone: "ft.com"
           name: "{{environment_tag}}-up"
+          emailAddress: "euan.finlay@ft.com"
         body_format: json
 
     - name: Wait 120s for instances to be terminated and release enis
@@ -57,4 +59,3 @@
         name: "coreos-up-{{clusterid}}"
         description: Fleet security group
         state: absent
-


### PR DESCRIPTION
Automatically raise CRs when deleting DNS records via Konstructor.

Currently uses my own email address due to limitations in Salesforce - have requested a service account to be set up so that we can use a group email instead, but that might take a week or longer.