### PR TITLE
Disabling swap in publishing clusters

### DIFF
--- a/ansible/userdata/persistent_instance_user_data.yaml
+++ b/ansible/userdata/persistent_instance_user_data.yaml
@@ -57,7 +57,7 @@ coreos:
             Environment="DOCKER_OPTS=--log-driver=none --host 0.0.0.0:2375"
       command: start
     - name: swapon.service
-      command: start
+      command: stop
       content: |
           [Unit]
           Description=Create swap


### PR DESCRIPTION
This has already been done in our delivery clusters, looks like we forgot to replicate in publishing.